### PR TITLE
:snail: Add Error boundary

### DIFF
--- a/src/WeatherApp/ErrorBoundary.tsx
+++ b/src/WeatherApp/ErrorBoundary.tsx
@@ -1,0 +1,45 @@
+// cf. https://ja.reactjs.org/docs/error-boundaries.html
+import React from 'react';
+
+type ErrorBoundaryProps = {
+  fallback: React.ReactNode;
+};
+
+type ErrorBoundaryState = {
+  hasError: boolean;
+  error?: Error;
+};
+
+// eslint-ignore: @typescript-eslint/ban-types
+export class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: undefined };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    // Update state so the next render will show the fallback UI.
+    console.log('Call getDerivedStateFromError!');
+
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    // You can also log the error to an error reporting service
+    console.log(error, errorInfo);
+  }
+
+  render(): React.ReactNode {
+    if (this.state.hasError) {
+      // You can render any custom fallback UI
+      console.log('ERROR!');
+
+      return this.props.fallback;
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/WeatherApp/components/WeatherResult.tsx
+++ b/src/WeatherApp/components/WeatherResult.tsx
@@ -20,7 +20,11 @@ const Container: VFC<WeatherContainerProps> = ({ children }) => {
 const WeatherResultContainer: VFC = () => {
   const weather = useRecoilValue(weatherState);
   const cityName = weather?.name;
-  console.log(weather);
+  console.log({ weather });
+
+  if (Number(weather?.cod) === 400) {
+    throw new Error(weather?.message);
+  }
 
   return (
     <Context.Provider value={!!cityName}>

--- a/src/WeatherApp/components/WeatherResult.tsx
+++ b/src/WeatherApp/components/WeatherResult.tsx
@@ -1,7 +1,6 @@
 import { createContext, ReactNode, Suspense, useContext, VFC } from 'react';
-import { useRecoilValue } from 'recoil';
 import { ErrorBoundary } from '../ErrorBoundary';
-import { weatherState } from '../recoil/selector/weatherState';
+import { useWeather } from '../hooks/useWeather';
 
 type HasWeather = boolean;
 
@@ -18,19 +17,13 @@ const Container: VFC<WeatherContainerProps> = ({ children }) => {
 };
 
 const WeatherResultContainer: VFC = () => {
-  const weather = useRecoilValue(weatherState);
-  const cityName = weather?.name;
-  console.log({ weather });
-
-  if (Number(weather?.cod) === 400) {
-    throw new Error(weather?.message);
-  }
+  const { weather } = useWeather();
 
   return (
-    <Context.Provider value={!!cityName}>
+    <Context.Provider value={!!weather}>
       <Container>
         <section>
-          <h2>{cityName}の天気</h2>
+          <h2>{weather?.name}の天気</h2>
           <div>
             {weather?.weather[0].main}: {weather?.main.temp}℃
           </div>

--- a/src/WeatherApp/components/WeatherResult.tsx
+++ b/src/WeatherApp/components/WeatherResult.tsx
@@ -1,5 +1,6 @@
 import { createContext, ReactNode, Suspense, useContext, VFC } from 'react';
 import { useRecoilValue } from 'recoil';
+import { ErrorBoundary } from '../ErrorBoundary';
 import { weatherState } from '../recoil/selector/weatherState';
 
 type HasWeather = boolean;
@@ -37,8 +38,10 @@ const WeatherResultContainer: VFC = () => {
 
 export const WeatherResult: VFC = () => {
   return (
-    <Suspense fallback={<p>Loading</p>}>
-      <WeatherResultContainer />
-    </Suspense>
+    <ErrorBoundary fallback={<p>Error</p>}>
+      <Suspense fallback={<p>Loading</p>}>
+        <WeatherResultContainer />
+      </Suspense>
+    </ErrorBoundary>
   );
 };

--- a/src/WeatherApp/hooks/useWeather.ts
+++ b/src/WeatherApp/hooks/useWeather.ts
@@ -1,0 +1,16 @@
+import { useRecoilValue } from 'recoil';
+import { weatherState } from '../recoil/selector/weatherState';
+
+export const useWeather = () => {
+  const weather = useRecoilValue(weatherState);
+  const errorMessage = weather?.message;
+  console.log({ weather });
+
+  if (errorMessage) {
+    throw new Error(errorMessage);
+  }
+
+  return {
+    weather,
+  };
+};

--- a/src/WeatherApp/models/openweathermap.ts
+++ b/src/WeatherApp/models/openweathermap.ts
@@ -38,5 +38,6 @@ export type Openweathermap = {
   timezone: number;
   id: number;
   name: string;
-  cod: number;
+  cod: number | string;
+  message?: string;
 };


### PR DESCRIPTION
## ErrorBoundary コンポーネントを追加

APIで発生したレスポンスのエラーでは ErrorBoundray コンポーネントに処理は流れなかった。  
意図的に `throw new Error()` をすると `ErrorBoundray` がエラーを拾い fallback を表示することができた。 

cf.

- https://ja.reactjs.org/docs/error-boundaries.html
- https://zenn.dev/rurm/articles/error-boundary
- https://marsquai.com/745ca65e-e38b-4a8e-8d59-55421be50f7e/f83dca4c-79db-4adf-b007-697c863b82a5/1df35b56-cba0-472f-8393-813e16a861c7/

---

Promise を返す selector をカスタムフックで利用しても内部的に Promise が throw されているようなのでコンポーネントがレダリングされない場合は `<Suspense />` の fallback を表示することができた

cf. 5bc0a04