### PR TITLE
⚡ Implement to refresh weather when click refresh button 

### DIFF
--- a/src/WeatherApp/components/WeatherForm.tsx
+++ b/src/WeatherApp/components/WeatherForm.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useState, VFC } from 'react';
 import { cities, CityIdType } from '../recoil/atom/cityIdState';
 import { useCitySelector } from '../hooks/useCitySelector';
+import { useRefreshWeatherByCityId } from '../hooks/useRefreshWeatherByCityId';
 
 export const WeatherForm: VFC = () => {
   const [cityId, setCityId] = useState<CityIdType>();
-  const { handleSetCityId } = useCitySelector();
+  const { cityId: cityIdState, handleSetCityId } = useCitySelector();
+  const { handleRefresh } = useRefreshWeatherByCityId(cityIdState);
 
   const handleChangeCity = useCallback(
     (evt: React.ChangeEvent<HTMLSelectElement>) => {
@@ -33,6 +35,9 @@ export const WeatherForm: VFC = () => {
         ))}
       </select>
       <button type="submit">SUBMIT</button>
+      <button type="button" onClick={handleRefresh}>
+        Refresh
+      </button>
     </form>
   );
 };

--- a/src/WeatherApp/hooks/useRefreshWeatherByCityId.ts
+++ b/src/WeatherApp/hooks/useRefreshWeatherByCityId.ts
@@ -1,0 +1,24 @@
+import { CityIdType } from '../recoil/atom/cityIdState';
+import { useSetRecoilState } from 'recoil';
+import { weatherRequestId } from '../recoil/atomFamily/weatherRequestId';
+import { useCallback } from 'react';
+
+interface IuseRefreshWeatherByCityId {
+  handleRefresh: () => void;
+}
+
+export const useRefreshWeatherByCityId = (
+  cityId: CityIdType,
+): IuseRefreshWeatherByCityId => {
+  const setCityWeatherQueryRefreshId = useSetRecoilState(
+    weatherRequestId(cityId),
+  );
+
+  const handleRefresh = useCallback(() => {
+    setCityWeatherQueryRefreshId((requestId) => requestId + 1);
+  }, [setCityWeatherQueryRefreshId]);
+
+  return {
+    handleRefresh,
+  };
+};

--- a/src/WeatherApp/hooks/useWeather.ts
+++ b/src/WeatherApp/hooks/useWeather.ts
@@ -1,13 +1,16 @@
 import { useRecoilValue } from 'recoil';
-import { weatherState } from '../recoil/selector/weatherState';
 import { Openweathermap } from '../models/openweathermap';
+import { cityIdState } from '../recoil/atom/cityIdState';
+import { weatherStateFamily } from '../recoil/selector/weatherStateFamily';
 
 interface IuseWeather {
   weather: Openweathermap | undefined;
 }
 
 export const useWeather = (): IuseWeather => {
-  const weather = useRecoilValue(weatherState);
+  const cityId = useRecoilValue(cityIdState);
+  const weather = useRecoilValue(weatherStateFamily(cityId));
+
   const errorMessage = weather?.message;
   console.log({ weather });
 

--- a/src/WeatherApp/hooks/useWeather.ts
+++ b/src/WeatherApp/hooks/useWeather.ts
@@ -1,7 +1,12 @@
 import { useRecoilValue } from 'recoil';
 import { weatherState } from '../recoil/selector/weatherState';
+import { Openweathermap } from '../models/openweathermap';
 
-export const useWeather = () => {
+interface IuseWeather {
+  weather: Openweathermap | undefined;
+}
+
+export const useWeather = (): IuseWeather => {
   const weather = useRecoilValue(weatherState);
   const errorMessage = weather?.message;
   console.log({ weather });

--- a/src/WeatherApp/recoil/atomFamily/weatherRequestId.ts
+++ b/src/WeatherApp/recoil/atomFamily/weatherRequestId.ts
@@ -1,0 +1,11 @@
+// Query Refresh ID state
+// https://recoiljs.org/docs/guides/asynchronous-data-queries#query-refresh
+
+import { atomFamily } from 'recoil';
+import { WEATHER_REQUEST_ID } from '../keys';
+import { CityIdType } from '../atom/cityIdState';
+
+export const weatherRequestId = atomFamily<number, CityIdType>({
+  key: WEATHER_REQUEST_ID,
+  default: 0,
+});

--- a/src/WeatherApp/recoil/keys.ts
+++ b/src/WeatherApp/recoil/keys.ts
@@ -1,2 +1,3 @@
 export const CITY_ID_STATE = 'cityIdState' as const;
 export const WEATHER_STATE = 'weatherState' as const;
+export const WEATHER_REQUEST_ID = 'weatherRequestId' as const;

--- a/src/WeatherApp/recoil/selector/weatherStateFamily.ts
+++ b/src/WeatherApp/recoil/selector/weatherStateFamily.ts
@@ -1,0 +1,35 @@
+import { selectorFamily } from 'recoil';
+import { API_KEY } from '../../config';
+import { WEATHER_STATE } from '../keys';
+import { Openweathermap } from '../../models/openweathermap';
+import { CityIdType } from '../atom/cityIdState';
+import { weatherRequestId } from '../atomFamily/weatherRequestId';
+
+type WeatherStateStateType = Openweathermap | undefined;
+
+export const weatherStateFamily = selectorFamily<
+  WeatherStateStateType,
+  CityIdType
+>({
+  key: WEATHER_STATE,
+  get: (cityId) => async ({ get }) => {
+    if (!cityId) {
+      return;
+    }
+
+    // Add request ID as a dependency
+    // cf. https://recoiljs.org/docs/guides/asynchronous-data-queries#query-refresh
+    // requestId が変更されているとキャッシュからではなく新しい値を返すようになる
+    // 値を使わなくても get していないと Refresh されない
+    const requestId = get(weatherRequestId(cityId));
+    console.log({ cityId, requestId });
+
+    // units: imperial = Fahrenheit, metric = Celsius, standard(default) = Kelvin
+    const res = await fetch(
+      `https://api.openweathermap.org/data/2.5/weather?id=${cityId}&appid=${API_KEY}&units=metric&lang=ja`,
+    );
+    const resJson = (await res.json()) as Openweathermap;
+
+    return resJson;
+  },
+});


### PR DESCRIPTION
# Query Refresh の実装

> When using selectors to model data queries, it's important to remember that selector evaluation should always provide a consistent value for a given state. Selectors represent state derived from other atom and selector states. Thus, selector evaluation functions should be idempotent for a given input, as it may be cached or executed multiple times. Practically, that means a single selector should not be used for a query where you expect the results to vary during the application's lifetime.  
> https://recoiljs.org/docs/guides/asynchronous-data-queries#query-refresh

Selector で API からデータを取得しているが、同じ state (`cityId`) が渡されたると Recoil はキャッシュからデータを返すので、新たに API からデータを取得できない状態だった。

`cityId` ごとにリクエスト数をカウントする state (`weatherRequestId`) を作成し、selector がこの state に依存することで、リクエストのカウント数が変わっていれば `cityId` が同じでも新たに API からデータを取得できるようになる。

cf.

- [リロードができない問題と解決策](https://dev.classmethod.jp/articles/react-recoil-weather-app/#toc-8)
- https://recoiljs.org/docs/guides/asynchronous-data-queries#query-refresh
- atomFamily
  - https://recoiljs.org/docs/api-reference/utils/atomFamily
  - https://tech.aptpod.co.jp/entry/2020/12/19/100000
- selectorFamily
  - https://recoiljs.org/docs/api-reference/utils/selectorFamily